### PR TITLE
feat: 添加 SonarQube 质量门徽章并更新版本号至 0.0.10-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Maven Build](https://github.com/rose-group/rose-build/actions/workflows/build.yml/badge.svg)](https://github.com/rose-group/rose-build/actions/workflows/build.yml)
 ![Maven](https://img.shields.io/maven-central/v/io.github.rose-group/rose-build.svg)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=io.github.rose-group%3Arose-build&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=io.github.rose-group%3Arose-build)
 ![License](https://img.shields.io/github/license/rose-group/rose-build.svg)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/rose-group/rose-build.svg)](http://isitmaintained.com/project/rose-group/rose-build "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/rose-group/rose-build.svg)](http://isitmaintained.com/project/rose-group/rose-build "Percentage of issues still open")

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.rose-group</groupId>
     <artifactId>rose-build</artifactId>
-    <version>0.0.5-SNAPSHOT</version>
+    <version>0.0.10-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Rose :: Build</name>
@@ -577,6 +577,18 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>sonar</id>
+            <properties>
+                <sonar.projectKey>${project.groupId}:${project.artifactId}</sonar.projectKey>
+                <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
+                <!--suppress UnresolvedMavenProperty -->
+                <sonar.coverage.jacoco.xmlReportPaths>
+                    ${maven.multiModuleProjectDirectory}/coverage/target/site/jacoco-aggregate/jacoco.xml
+                </sonar.coverage.jacoco.xmlReportPaths>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
- 在 README.md 中添加 SonarQube 质量门状态徽章
- 更新 pom.xml 文件中的项目版本号至 0.0.10-SNAPSHOT
- 添加新的 Maven 构建配置文件 sonar 配置，支持 SonarQube 分析