### PR TITLE
chore: 更新 maven 插件版本和移除不必要的仓库配置

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
     <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
     <maven-project-info-reports-plugin.version>3.6.2</maven-project-info-reports-plugin.version>
-    <maven.site.plugin.version>4.0.0-M16</maven.site.plugin.version>
+    <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <pitest-maven.version>1.17.4</pitest-maven.version>
@@ -849,18 +849,4 @@
       <url>scm:git:git@github.com:chensoul/rose-group/rose-build.git</url>
     </site>
   </distributionManagement>
-
-  <repositories>
-    <repository>
-      <id>central</id>
-      <name>central-snapshot</name>
-      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -20,6 +20,6 @@
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>2.0.0-M11</version>
+        <version>2.1.0</version>
     </skin>
 </site>


### PR DESCRIPTION
- 将 maven-site-plugin 版本从 4.0.0-M16 降级到 3.21.0
- 更新 maven-fluido-skin 版本从 2.0.0-M11 到 2.1.0
- 移除 central-snapshot 仓库配置