### PR TITLE
chore: 添加 site 配置到 pom.xml 文件中

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -832,5 +832,9 @@
       <name>central-snapshot</name>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
+    <site>
+      <id>site</id>
+      <url>${project.scm.developerConnection}</url>
+    </site>
   </distributionManagement>
 </project>


### PR DESCRIPTION
在 distributionManagement 中添加了 site 配置，包含 id 和 url 属性，用于支持项目站点部署。